### PR TITLE
Make table name methods virtual for extensibility

### DIFF
--- a/src/DotNetCore.CAP.Sqlite/IStorageInitializer.Sqlite.cs
+++ b/src/DotNetCore.CAP.Sqlite/IStorageInitializer.Sqlite.cs
@@ -27,17 +27,17 @@ public class SqliteStorageInitializer : IStorageInitializer
 
     }
 
-    public string GetPublishedTableName()
+    public virtual string GetPublishedTableName()
     {
         return $"{_tablePrefix}.Published";
     }
 
-    public string GetReceivedTableName()
+    public virtual string GetReceivedTableName()
     {
         return $"{_tablePrefix}.Received";
     }
 
-    public string GetLockTableName()
+    public virtual string GetLockTableName()
     {
         return $"{_tablePrefix}.Locks";
     }


### PR DESCRIPTION
## Summary

Marks `GetPublishedTableName()`, `GetReceivedTableName()`, and `GetLockTableName()` as `virtual` on `SqliteStorageInitializer`, allowing subclasses to override them to customize table names.

This aligns with the `SqlServerStorageInitializer` in the main CAP repo, where these methods are already `virtual`.

Fixes #23

## Changes

- Added `virtual` modifier to `GetPublishedTableName()`
- Added `virtual` modifier to `GetReceivedTableName()`
- Added `virtual` modifier to `GetLockTableName()`

This is a non-breaking change — existing code that doesn't override these methods will behave identically.